### PR TITLE
type annotations with linting errors resolved

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { SelectAdvocate } from '@/db/schema';
+import { useEffect, useRef, useState } from "react";
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [advocates, setAdvocates] = useState<SelectAdvocate[]>([]);
+  const [filteredAdvocates, setFilteredAdvocates] = useState<SelectAdvocate[]>([]);
+  const searchTerm = useRef<string>('');
 
   useEffect(() => {
     console.log("fetching advocates...");
@@ -16,20 +18,22 @@ export default function Home() {
     });
   }, []);
 
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    searchTerm.current = e.target.value;
 
     console.log("filtering advocates...");
+    const lowerCaseSearch = searchTerm.current.toLowerCase();
+
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.firstName.toLowerCase().includes(lowerCaseSearch) ||
+        advocate.lastName.toLowerCase().includes(lowerCaseSearch) ||
+        advocate.city.toLowerCase().includes(lowerCaseSearch) ||
+        advocate.degree.toLowerCase().includes(lowerCaseSearch) ||
+        advocate.specialties.some((specialty) => {
+          specialty.toLowerCase().includes(lowerCaseSearch)
+        }) ||
+        advocate.yearsOfExperience.toString().includes(lowerCaseSearch)
       );
     });
 
@@ -49,7 +53,7 @@ export default function Home() {
       <div>
         <p>Search</p>
         <p>
-          Searching for: <span id="search-term"></span>
+          Searching for: <span id="search-term">{searchTerm.current}</span>
         </p>
         <input style={{ border: "1px solid black" }} onChange={onChange} />
         <button onClick={onClick}>Reset Search</button>
@@ -69,14 +73,14 @@ export default function Home() {
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={s}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,19 +1,15 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import * as schema from "./schema";
 
 const setup = () => {
   if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    throw new Error("No DATABASE_URL found. Connection to DB failed.");
   }
 
   // for query purposes
   const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
+  const db = drizzle(queryClient, { schema });
   return db;
 };
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql, type InferSelectModel, type InferInsertModel } from "drizzle-orm";
 import {
   pgTable,
   integer,
@@ -15,10 +15,17 @@ const advocates = pgTable("advocates", {
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),
   degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
+  specialties: jsonb("payload").default([]).notNull().$type<string[]>(),
   yearsOfExperience: integer("years_of_experience").notNull(),
   phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 
-export { advocates };
+type SelectAdvocate = InferSelectModel<typeof advocates>;
+type InsertAdvocate = InferInsertModel<typeof advocates>;
+
+export {
+  advocates,
+  type SelectAdvocate,
+  type InsertAdvocate
+};


### PR DESCRIPTION
- Added and exported types for the `advocates` schema from Drizzle ORM.  (This is a new tool for me, thanks for the introduction!)

- Updated the `onChange` function to set `ref.current` (on the newly created `searchRef`), rather than updating innerHTML with native JS DOM manipulation.

- Used the value of `searchRef.current` as the rendered text next to "Searching For:"

- Normalized the data from the ref to be lowercased to check against DB values (also lowercased, to allow users to search based on a query, regardless of casing)

- Added the `key` prop to JSX rendered in `.map` calls.

- Added `{ schema }` to the drizzle call.  If I'm being completely honest, I just saw this in a stack overflow post, I didn't see any errors so I placed it in there, would love to hear more about what this provides :/

**_Generally , on this PR I just updated the code to resolve TS/React errors, although better improvements will be in the next PR_**